### PR TITLE
note: Add the ability to set template format to "compact".

### DIFF
--- a/src/note.rs
+++ b/src/note.rs
@@ -133,6 +133,7 @@ impl<'a, IOM: Write<SevenBitAddress> + Read<SevenBitAddress>, const BS: usize> N
         self,
         delay: &mut impl DelayMs<u16>,
         file: Option<&str>,
+        format: Option<&str>,
         body: Option<T>,
         length: Option<u32>,
     ) -> Result<FutureResponse<'a, res::Template, IOM, BS>, NoteError> {
@@ -141,6 +142,7 @@ impl<'a, IOM: Write<SevenBitAddress> + Read<SevenBitAddress>, const BS: usize> N
             req::Template::<T> {
                 req: "note.template",
                 file: file.map(heapless::String::from),
+                format: format.map(heapless::String::from),
                 body,
                 length,
             },
@@ -220,6 +222,9 @@ mod req {
 
         #[serde(skip_serializing_if = "Option::is_none")]
         pub file: Option<heapless::String<20>>,
+
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub format: Option<heapless::String<20>>,
 
         #[serde(skip_serializing_if = "Option::is_none")]
         pub body: Option<T>,


### PR DESCRIPTION
As far as the notecard documentation goes there currently only seems to be a None or "compact" formats. https://dev.blues.io/api-reference/notecard-api/note-requests/latest/#note-template

But it probably make sense to leave this to be a string so if blues decides to add more formats it will be easy to use? But we can discuss using some kind of an Enum instead if that makes more sense.