### PR TITLE
api: Derive Debug for all the api structs

### DIFF
--- a/src/card.rs
+++ b/src/card.rs
@@ -267,16 +267,17 @@ impl<'a, IOM: Write<SevenBitAddress> + Read<SevenBitAddress>, const BS: usize> C
 }
 
 pub mod req {
+
     use super::*;
 
-    #[derive(Deserialize, Serialize, defmt::Format, Default)]
+    #[derive(Deserialize, Serialize, Debug, defmt::Format, Default)]
     pub struct Aux {
         pub req: &'static str,
         pub mode: &'static str,
         pub usage: [&'static str; 4],
     }
 
-    #[derive(Deserialize, Serialize, defmt::Format, Default)]
+    #[derive(Deserialize, Serialize, Debug, defmt::Format, Default)]
     pub struct Transport {
         pub req: &'static str,
 
@@ -293,7 +294,7 @@ pub mod req {
         pub seconds: Option<u32>,
     }
 
-    #[derive(Deserialize, Serialize, defmt::Format, Default)]
+    #[derive(Deserialize, Serialize, Debug, defmt::Format, Default)]
     pub struct Wireless {
         pub req: &'static str,
 
@@ -310,7 +311,7 @@ pub mod req {
         pub hours: Option<u32>,
     }
 
-    #[derive(Deserialize, Serialize, defmt::Format, Default)]
+    #[derive(Deserialize, Serialize, Debug, defmt::Format, Default)]
     pub struct LocationTrack {
         pub req: &'static str,
 
@@ -333,7 +334,7 @@ pub mod req {
         pub file: Option<heapless::String<20>>,
     }
 
-    #[derive(Deserialize, Serialize, defmt::Format, Default)]
+    #[derive(Deserialize, Serialize, Debug, defmt::Format, Default)]
     pub struct LocationMode {
         pub req: &'static str,
 
@@ -362,7 +363,7 @@ pub mod req {
         pub minutes: Option<u32>,
     }
 
-    #[derive(Deserialize, Serialize, defmt::Format, PartialEq, Debug)]
+    #[derive(Deserialize, Serialize, Debug, defmt::Format, PartialEq)]
     #[serde(rename_all = "lowercase")]
     pub enum DFUName {
         Esp32,
@@ -374,7 +375,7 @@ pub mod req {
         Reset,
     }
 
-    #[derive(Deserialize, Serialize, defmt::Format)]
+    #[derive(Deserialize, Serialize, Debug, defmt::Format)]
     pub struct DFU {
         pub req: &'static str,
 
@@ -416,10 +417,10 @@ pub mod req {
 pub mod res {
     use super::*;
 
-    #[derive(Deserialize, defmt::Format)]
+    #[derive(Deserialize, Debug, defmt::Format)]
     pub struct Empty {}
 
-    #[derive(Deserialize, defmt::Format)]
+    #[derive(Deserialize, Debug, defmt::Format)]
     pub struct LocationTrack {
         pub start: Option<bool>,
         pub stop: Option<bool>,
@@ -429,7 +430,7 @@ pub mod res {
         pub file: Option<heapless::String<20>>,
     }
 
-    #[derive(Deserialize, defmt::Format)]
+    #[derive(Deserialize, Debug, defmt::Format)]
     pub struct Aux {
         pub mode: Option<heapless::String<20>>,
         pub power: Option<bool>,
@@ -438,7 +439,7 @@ pub mod res {
         pub state: Option<[GpioState; 4]>,
     }
 
-    #[derive(Deserialize, defmt::Format)]
+    #[derive(Deserialize, Debug, defmt::Format)]
     pub struct GpioState {
         pub low: Option<bool>,
         pub high: Option<bool>,
@@ -446,7 +447,7 @@ pub mod res {
         pub count: Option<heapless::Vec<u32, 128>>,
     }
 
-    #[derive(Deserialize, defmt::Format)]
+    #[derive(Deserialize, Debug, defmt::Format)]
     pub struct LocationMode {
         pub mode: heapless::String<60>,
         pub seconds: Option<u32>,
@@ -457,7 +458,7 @@ pub mod res {
         pub minutes: Option<u32>,
     }
 
-    #[derive(Deserialize, defmt::Format)]
+    #[derive(Deserialize, Debug, defmt::Format)]
     pub struct Location {
         pub status: heapless::String<120>,
         pub mode: heapless::String<120>,
@@ -467,7 +468,7 @@ pub mod res {
         pub max: Option<u32>,
     }
 
-    #[derive(Deserialize, defmt::Format)]
+    #[derive(Deserialize, Debug, defmt::Format)]
     pub struct Time {
         pub time: Option<u32>,
         pub area: Option<heapless::String<120>>,
@@ -478,7 +479,7 @@ pub mod res {
         pub country: Option<heapless::String<120>>,
     }
 
-    #[derive(Deserialize, defmt::Format)]
+    #[derive(Deserialize, Debug, defmt::Format)]
     pub struct Status {
         pub status: heapless::String<40>,
         #[serde(default)]
@@ -489,7 +490,7 @@ pub mod res {
         pub connected: bool,
     }
 
-    #[derive(Deserialize, defmt::Format)]
+    #[derive(Deserialize, Debug, defmt::Format)]
     pub struct WirelessNet {
         iccid: Option<heapless::String<24>>,
         imsi: Option<heapless::String<24>>,
@@ -513,7 +514,7 @@ pub mod res {
         updated: Option<u32>,
     }
 
-    #[derive(Deserialize, defmt::Format)]
+    #[derive(Deserialize, Debug, defmt::Format)]
     pub struct Wireless {
         pub status: Option<heapless::String<24>>,
         pub mode: Option<heapless::String<24>>,
@@ -521,7 +522,7 @@ pub mod res {
         pub net: Option<WirelessNet>,
     }
 
-    #[derive(Deserialize, defmt::Format)]
+    #[derive(Deserialize, Debug, defmt::Format)]
     pub struct VersionInner {
         pub org: heapless::String<24>,
         pub product: heapless::String<24>,
@@ -534,7 +535,7 @@ pub mod res {
         pub target: Option<heapless::String<5>>,
     }
 
-    #[derive(Deserialize, defmt::Format)]
+    #[derive(Deserialize, Debug, defmt::Format)]
     pub struct Version {
         pub body: VersionInner,
         pub version: heapless::String<24>,
@@ -548,12 +549,12 @@ pub mod res {
         pub ordering_code: Option<heapless::String<50>>,
     }
 
-    #[derive(Deserialize, defmt::Format)]
+    #[derive(Deserialize, Debug, defmt::Format)]
     pub struct DFU {
         pub name: req::DFUName,
     }
 
-    #[derive(Deserialize, defmt::Format)]
+    #[derive(Deserialize, Debug, defmt::Format)]
     pub struct Transport {
         pub method: heapless::String<120>,
     }

--- a/src/dfu.rs
+++ b/src/dfu.rs
@@ -63,7 +63,7 @@ impl<'a, IOM: Write<SevenBitAddress> + Read<SevenBitAddress>, const BS: usize> D
 pub mod req {
     use super::*;
 
-    #[derive(Serialize, Deserialize, defmt::Format, Default)]
+    #[derive(Serialize, Deserialize, Debug, defmt::Format, Default)]
     pub struct Get {
         pub req: &'static str,
 
@@ -73,14 +73,14 @@ pub mod req {
         pub offset: Option<usize>,
     }
 
-    #[derive(Serialize, Deserialize, defmt::Format, PartialEq, Debug)]
+    #[derive(Serialize, Deserialize, Debug, defmt::Format, PartialEq)]
     #[serde(rename_all = "lowercase")]
     pub enum StatusName {
         User,
         Card,
     }
 
-    #[derive(Serialize, Deserialize, defmt::Format)]
+    #[derive(Serialize, Deserialize, Debug, defmt::Format)]
     pub struct Version<'a> {
         #[serde(skip_serializing_if = "Option::is_none")]
         pub org: Option<&'a str>,
@@ -102,7 +102,7 @@ pub mod req {
         pub builder: Option<&'a str>,
     }
 
-    #[derive(Serialize, Deserialize, defmt::Format, Default)]
+    #[derive(Serialize, Deserialize, Debug, defmt::Format, Default)]
     pub struct Status<'a> {
         pub req: &'static str,
 
@@ -163,7 +163,7 @@ pub mod req {
 pub mod res {
     use super::*;
 
-    #[derive(Deserialize, defmt::Format)]
+    #[derive(Deserialize, Debug, defmt::Format)]
     pub struct Get<const PS: usize> {
         pub payload: heapless::String<PS>,
     }
@@ -178,7 +178,7 @@ pub mod res {
         Completed,
     }
 
-    #[derive(Deserialize, defmt::Format)]
+    #[derive(Deserialize, Debug, defmt::Format)]
     pub struct StatusBody {
         pub crc32: Option<u32>,
         pub created: Option<u32>,
@@ -193,7 +193,7 @@ pub mod res {
         pub bin_type: Option<heapless::String<120>>,
     }
 
-    #[derive(Deserialize, defmt::Format)]
+    #[derive(Deserialize, Debug, defmt::Format)]
     pub struct Status {
         pub mode: StatusMode,
         pub status: Option<heapless::String<120>>,

--- a/src/hub.rs
+++ b/src/hub.rs
@@ -120,7 +120,7 @@ impl<'a, IOM: Write<SevenBitAddress> + Read<SevenBitAddress>, const BS: usize> H
 pub mod req {
     use super::*;
 
-    #[derive(Deserialize, Serialize, defmt::Format, Default)]
+    #[derive(Deserialize, Serialize, Debug, defmt::Format, Default)]
     pub struct HubSync {
         pub req: &'static str,
 
@@ -134,7 +134,7 @@ pub mod req {
         pub inn: Option<bool>,
     }
 
-    #[derive(Deserialize, Serialize, defmt::Format)]
+    #[derive(Deserialize, Serialize, Debug, defmt::Format)]
     #[serde(rename_all = "lowercase")]
     pub enum HubMode {
         Periodic,
@@ -144,7 +144,7 @@ pub mod req {
         DFU,
     }
 
-    #[derive(Deserialize, Serialize, defmt::Format, Default)]
+    #[derive(Deserialize, Serialize, Debug, defmt::Format, Default)]
     pub struct HubSet<'a> {
         pub req: &'static str,
 
@@ -181,7 +181,7 @@ pub mod req {
         pub sync: Option<bool>,
     }
 
-    #[derive(Deserialize, Serialize, defmt::Format, Default)]
+    #[derive(Deserialize, Serialize, Debug, defmt::Format, Default)]
     pub struct HubLog<'a> {
         pub req: &'static str,
         pub text: &'a str,
@@ -193,10 +193,10 @@ pub mod req {
 pub mod res {
     use super::*;
 
-    #[derive(Deserialize, defmt::Format)]
+    #[derive(Deserialize, Debug, defmt::Format)]
     pub struct Empty {}
 
-    #[derive(Deserialize, defmt::Format)]
+    #[derive(Deserialize, Debug, defmt::Format)]
     pub struct Hub {
         pub device: Option<heapless::String<40>>,
         pub product: Option<heapless::String<120>>,
@@ -210,7 +210,7 @@ pub mod res {
         pub sync: Option<bool>,
     }
 
-    #[derive(Deserialize, defmt::Format)]
+    #[derive(Deserialize, Debug, defmt::Format)]
     pub struct SyncStatus {
         pub status: Option<heapless::String<1024>>,
         pub time: Option<u32>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,7 @@ pub(crate) fn str_string<const N: usize>(
         .map_err(NoteError::string_err)
 }
 
-#[derive(Deserialize, defmt::Format)]
+#[derive(Deserialize, Debug, defmt::Format)]
 pub struct NotecardError {
     err: String<256>,
 }

--- a/src/note.rs
+++ b/src/note.rs
@@ -176,7 +176,7 @@ impl<'a, IOM: Write<SevenBitAddress> + Read<SevenBitAddress>, const BS: usize> N
 mod req {
     use super::*;
 
-    #[derive(Deserialize, Serialize, Default)]
+    #[derive(Deserialize, Serialize, Debug, defmt::Format, Default)]
     pub struct Add<'a, T: Serialize + Default> {
         pub req: &'static str,
 
@@ -202,7 +202,7 @@ mod req {
         pub verify: Option<bool>,
     }
 
-    #[derive(Deserialize, Serialize, Default)]
+    #[derive(Deserialize, Serialize, Debug, defmt::Format, Default)]
     pub struct Update<'a, T: Serialize + Default> {
         pub req: &'static str,
 
@@ -218,7 +218,7 @@ mod req {
         pub verify: bool,
     }
 
-    #[derive(Deserialize, Serialize, Default)]
+    #[derive(Deserialize, Serialize, Debug, defmt::Format, Default)]
     pub struct Delete {
         pub req: &'static str,
 
@@ -227,7 +227,7 @@ mod req {
         pub verify: bool,
     }
 
-    #[derive(Deserialize, Serialize, Default)]
+    #[derive(Deserialize, Serialize, Debug, defmt::Format, Default)]
     pub struct Get {
         pub req: &'static str,
 
@@ -238,7 +238,7 @@ mod req {
         pub deleted: bool,
     }
 
-    #[derive(Deserialize, Serialize, Default)]
+    #[derive(Deserialize, Serialize, Debug, defmt::Format, Default)]
     pub struct Template<T: Serialize + Default> {
         pub req: &'static str,
 
@@ -265,10 +265,10 @@ mod req {
 pub mod res {
     use super::*;
 
-    #[derive(Deserialize, defmt::Format)]
+    #[derive(Deserialize, Debug, defmt::Format)]
     pub struct Empty {}
 
-    #[derive(Debug, Deserialize, defmt::Format)]
+    #[derive(Deserialize, Debug, defmt::Format)]
     pub struct Get<T: Serialize> {
         pub note: heapless::String<32>,
 
@@ -282,13 +282,13 @@ pub mod res {
         pub time: Option<u32>,
     }
 
-    #[derive(Deserialize, defmt::Format)]
+    #[derive(Deserialize, Debug, defmt::Format)]
     pub struct Add {
         total: Option<u32>,
         template: Option<bool>,
     }
 
-    #[derive(Deserialize, defmt::Format)]
+    #[derive(Deserialize, Debug, defmt::Format)]
     pub struct Template {
         pub bytes: u32,
 

--- a/src/ntn.rs
+++ b/src/ntn.rs
@@ -68,7 +68,7 @@ impl<'a, IOM: Write<SevenBitAddress> + Read<SevenBitAddress>, const BS: usize> N
 pub mod req {
     use super::*;
 
-    #[derive(Deserialize, Serialize, defmt::Format, Default)]
+    #[derive(Deserialize, Serialize, Debug, defmt::Format, Default)]
     pub struct Gps {
         pub req: &'static str,
 
@@ -83,10 +83,10 @@ pub mod req {
 pub mod res {
     use super::*;
 
-    #[derive(Deserialize, defmt::Format)]
+    #[derive(Deserialize, Debug, defmt::Format)]
     pub struct Empty {}
 
-    #[derive(Deserialize, Serialize, defmt::Format, Default)]
+    #[derive(Deserialize, Serialize, Debug, defmt::Format, Default)]
     pub struct Gps {
         #[serde(skip_serializing_if = "Option::is_none")]
         pub on: Option<bool>,
@@ -95,7 +95,7 @@ pub mod res {
         pub off: Option<bool>,
     }
 
-    #[derive(Deserialize, defmt::Format)]
+    #[derive(Deserialize, Debug, defmt::Format)]
     pub struct Status {
         pub err: Option<heapless::String<120>>,
         pub status: Option<heapless::String<120>>,

--- a/src/web.rs
+++ b/src/web.rs
@@ -54,7 +54,7 @@ impl<'a, IOM: Write<SevenBitAddress> + Read<SevenBitAddress>, const BS: usize> W
 mod req {
     use super::*;
 
-    #[derive(Deserialize, Serialize, Default)]
+    #[derive(Deserialize, Serialize, Debug, defmt::Format, Default)]
     pub struct Post<'a, T: Serialize + Default> {
         pub req: &'static str,
 
@@ -89,7 +89,7 @@ mod req {
 pub mod res {
     use super::*;
 
-    #[derive(Deserialize, defmt::Format)]
+    #[derive(Deserialize, Debug, defmt::Format)]
     pub struct Post {
         result: Option<u32>,
         // body: Option<&'a str>,


### PR DESCRIPTION
This allows for easier application debugging and logging.

We were already deriving Debug for some structs but not consistently.

In case defmt is not being used Debug tends to be used instead, so we should provide it.

We can add ufmt support too, but that is a separate feature.

Closes #20 