### PR TITLE
Easier to debug serde error output using serde_path_to_error crate.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,5 +26,5 @@ jobs:
         run: cargo build --verbose
 
       - name: Test
-        run: cargo test --features testing --verbose
+        run: cargo test --verbose
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ serde-json-core = "0.5.1"
 base64 = { version = "0.13.0", default-features = false }
 bytemuck = "1.7.2"
 embedded-hal-mock = "0.10.0"
+defmt = { version = "1.0", features = [ "unstable-test" ] }
 
 [features]
 default = [ ]
-testing = [ "defmt/unstable-test" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ base64 = { version = "0.13.0", default-features = false }
 bytemuck = "1.7.2"
 embedded-hal-mock = "0.10.0"
 defmt = { version = "1.0", features = [ "unstable-test" ] }
+serde_path_to_error = "0.1.16"
+serde_json = "1.0.138"
 
 [features]
 default = [ ]

--- a/src/card.rs
+++ b/src/card.rs
@@ -586,38 +586,53 @@ mod tests {
   "sku":     "NOTE-WBNA500",
   "api":     1
 }"##;
-        serde_json_core::from_slice::<res::Version>(r).unwrap();
+        let d = &mut serde_json::Deserializer::from_slice(r);
+        serde_path_to_error::deserialize::<_, res::Version>(d).unwrap();
     }
 
     #[test]
     fn test_version_411() {
         let r = br##"{"version":"notecard-4.1.1.4015681","device":"dev:000000000000000","name":"Blues Wireless Notecard","sku":"NOTE-WBEX-500","board":"1.11","api":4,"body":{"org":"Blues Wireless","product":"Notecard","version":"notecard-4.1.1","ver_major":4,"ver_minor":1,"ver_patch":1,"ver_build":4015681,"built":"Dec  5 2022 12:54:58"}}"##;
-        serde_json_core::from_slice::<res::Version>(r).unwrap();
+        let d = &mut serde_json::Deserializer::from_slice(r);
+        serde_path_to_error::deserialize::<_, res::Version>(d).unwrap();
+    }
+
+    #[test]
+    fn test_version_813() {
+        let r = br##"{"version":"notecard-8.1.3.17044","device":"dev:000000000000000","name":"Blues Wireless Notecard","sku":"NOTE-WBNAN","ordering_code":"EA0WT1N0AXBB","board":"5.13","cell":true,"gps":true,"body":{"org":"Blues Wireless","product":"Notecard","target":"u5","version":"notecard-u5-8.1.3","ver_major":8,"ver_minor":1,"ver_patch":3,"ver_build":17044,"built":"Dec 20 2024 08:45:13"}}"##;
+        let d = &mut serde_json::Deserializer::from_slice(r);
+        serde_path_to_error::deserialize::<_, res::Version>(d).unwrap();
     }
 
     #[test]
     fn test_version_752() {
         let r = br##"{"version":"notecard-7.5.2.17004","device":"dev:861059067974133","name":"Blues Wireless Notecard","sku":"NOTE-NBGLN","ordering_code":"EB0WT1N0AXBA","board":"5.13","cell":true,"gps":true,"body":{"org":"Blues Wireless","product":"Notecard","target":"u5","version":"notecard-u5-7.5.2","ver_major":7,"ver_minor":5,"ver_patch":2,"ver_build":17004,"built":"Nov 26 2024 14:01:26"}}"##;
-        serde_json_core::from_slice::<res::Version>(r).unwrap();
+        let d = &mut serde_json::Deserializer::from_slice(r);
+        serde_path_to_error::deserialize::<_, res::Version>(d).unwrap();
     }
 
     #[test]
     fn test_card_wireless() {
         let r = br##"{"status":"{modem-on}","count":3,"net":{"iccid":"89011703278520607527","imsi":"310170852060752","imei":"864475044204278","modem":"BG95M3LAR02A03_01.006.01.006","band":"GSM 900","rat":"gsm","rssir":-77,"rssi":-77,"bars":3,"mcc":242,"mnc":1,"lac":11001,"cid":12313,"updated":1643923524}}"##;
-        serde_json_core::from_slice::<res::Wireless>(r).unwrap();
+        let d = &mut serde_json::Deserializer::from_slice(r);
+        serde_path_to_error::deserialize::<_, res::Wireless>(d).unwrap();
 
         let r = br##"{"status":"{cell-registration-wait}","net":{"iccid":"89011703278520606586","imsi":"310170852060658","imei":"864475044197092","modem":"BG95M3LAR02A03_01.006.01.006"}}"##;
-        serde_json_core::from_slice::<res::Wireless>(r).unwrap();
+        let d = &mut serde_json::Deserializer::from_slice(r);
+        serde_path_to_error::deserialize::<_, res::Wireless>(d).unwrap();
 
         let r = br##"{"status":"{modem-off}","net":{}}"##;
-        serde_json_core::from_slice::<res::Wireless>(r).unwrap();
+        let d = &mut serde_json::Deserializer::from_slice(r);
+        serde_path_to_error::deserialize::<_, res::Wireless>(d).unwrap();
 
         let r = br##"{"status":"{network-up}","mode":"auto","count":3,"net":{"iccid":"89011703278520578660","imsi":"310170852057866","imei":"867730051260788","modem":"BG95M3LAR02A03_01.006.01.006","band":"GSM 900","rat":"gsm","rssir":-77,"rssi":-78,"bars":3,"mcc":242,"mnc":1,"lac":11,"cid":12286,"updated":1646227929}}"##;
-        serde_json_core::from_slice::<res::Wireless>(r).unwrap();
+        let d = &mut serde_json::Deserializer::from_slice(r);
+        serde_path_to_error::deserialize::<_, res::Wireless>(d).unwrap();
 
         // NTN
         let r = br##"{"mode":"auto","count":2,"net":{"iccid":"89011704278930030582","imsi":"310170893003058","imei":"860264054655247","modem":"EG91EXGAR08A05M1G_01.001.01.001","band":"LTE BAND 20","rat":"lte","ratr":"\"LTE\"","internal":true,"rssir":-59,"rssi":-60,"rsrp":-92,"sinr":15,"rsrq":-9,"bars":2,"mcc":242,"mnc":2,"lac":2501,"cid":35398693,"modem_temp":34,"updated":1746004605}}"##;
-        serde_json_core::from_slice::<res::Wireless>(r).unwrap();
+        let d = &mut serde_json::Deserializer::from_slice(r);
+        serde_path_to_error::deserialize::<_, res::Wireless>(d).unwrap();
     }
 
     #[test]
@@ -634,7 +649,8 @@ mod tests {
         }
         "##;
 
-        serde_json_core::from_slice::<res::Time>(r).unwrap();
+        let d = &mut serde_json::Deserializer::from_slice(r);
+        serde_path_to_error::deserialize::<_, res::Time>(d).unwrap();
     }
 
     #[test]
@@ -651,18 +667,20 @@ mod tests {
         }
         "##;
 
-        serde_json_core::from_slice::<res::Time>(r).unwrap();
+        let d = &mut serde_json::Deserializer::from_slice(r);
+        serde_path_to_error::deserialize::<_, res::Time>(d).unwrap();
     }
 
     #[test]
     fn test_card_time_err() {
         let r = br##"{"err":"time is not yet set","zone":"UTC,Unknown"}"##;
-        serde_json_core::from_slice::<NotecardError>(r).unwrap();
+        let d = &mut serde_json::Deserializer::from_slice(r);
+        serde_path_to_error::deserialize::<_, NotecardError>(d).unwrap();
     }
 
     #[test]
     pub fn test_status_ok() {
-        serde_json_core::from_str::<res::Status>(
+        let d = &mut serde_json::Deserializer::from_str(
             r#"
           {
             "status":    "{normal}",
@@ -671,47 +689,50 @@ mod tests {
             "time":      1599684765,
             "connected": true
           }"#,
-        )
-        .unwrap();
+        );
+        serde_path_to_error::deserialize::<_, res::Status>(d).unwrap();
     }
 
     #[test]
     pub fn test_status_mising() {
-        serde_json_core::from_str::<res::Status>(
+        let d = &mut serde_json::Deserializer::from_str(
             r#"
           {
             "status":    "{normal}",
             "usb":       true,
             "storage":   8
           }"#,
-        )
-        .unwrap();
+        );
+
+        serde_path_to_error::deserialize::<_, res::Status>(d).unwrap();
     }
 
     #[test]
     fn test_partial_location_mode() {
-        serde_json_core::from_str::<res::LocationMode>(r#"{"seconds":60,"mode":"periodic"}"#)
-            .unwrap();
+        let d = &mut serde_json::Deserializer::from_str(r#"{"seconds":60,"mode":"periodic"}"#);
+
+        serde_path_to_error::deserialize::<_, res::LocationMode>(d).unwrap();
     }
 
     #[test]
     fn test_parse_exceed_string_size() {
-        serde_json_core::from_str::<res::LocationMode>(
-            r#"{"seconds":60,"mode":"periodicperiodicperiodicperiodicperiodicperiodicperiodic"}"#,
-        )
+        let d = &mut serde_json::Deserializer::from_str(r#"{"seconds":60,"mode":"periodicperiodicperiodicperiodicperiodicperiodicperiodic"}"#);
+        serde_path_to_error::deserialize::<_, res::LocationMode>(d)
         .ok();
     }
 
     #[test]
     fn test_location_searching() {
-        serde_json_core::from_str::<res::Location>(
-            r#"{"status":"GPS search (111 sec, 32/33 dB SNR, 0/1 sats) {gps-active} {gps-signal} {gps-sats}","mode":"continuous"}"#).unwrap();
+        let d = &mut serde_json::Deserializer::from_str(
+            r#"{"status":"GPS search (111 sec, 32/33 dB SNR, 0/1 sats) {gps-active} {gps-signal} {gps-sats}","mode":"continuous"}"#);
+        serde_path_to_error::deserialize::<_, res::Location>(d).unwrap();
     }
 
     #[test]
     fn test_location_mode_err() {
         let r = br##"{"err":"seconds: field seconds: unmarshal: expected a int32 {io}"}"##;
-        serde_json_core::from_slice::<NotecardError>(r).unwrap();
+        let d = &mut serde_json::Deserializer::from_slice(r);
+        serde_path_to_error::deserialize::<_, NotecardError>(d).unwrap();
     }
 
     #[test]
@@ -758,13 +779,13 @@ mod tests {
 
     #[test]
     fn test_dfu_res() {
-        serde_json_core::from_str::<res::DFU>(r#"{"name": "stm32"}"#).unwrap();
+        let d = &mut serde_json::Deserializer::from_str(r#"{"name": "stm32"}"#);
+        serde_path_to_error::deserialize::<_, res::DFU>(d).unwrap();
     }
 
     #[test]
     fn test_parse_aux_gpio_state() {
-        serde_json_core::from_str::<res::Aux>(
-            r#"{
+        let d = &mut serde_json::Deserializer::from_str(r#"{
   "mode": "gpio",
   "state": [
     {},
@@ -782,8 +803,7 @@ mod tests {
   ],
   "time": 1592587637,
   "seconds": 2
-}"#,
-        )
-        .unwrap();
+}"#);
+        serde_path_to_error::deserialize::<_, res::Aux>(d).unwrap();
     }
 }

--- a/src/dfu.rs
+++ b/src/dfu.rs
@@ -210,9 +210,8 @@ mod tests {
 
     #[test]
     fn test_get() {
-        let (res, _) =
-            serde_json_core::from_str::<res::Get<32>>(r#"{"payload":"THISISALOTOFBINARYDATA="}"#)
-                .unwrap();
+        let d = &mut serde_json::Deserializer::from_str(r#"{"payload":"THISISALOTOFBINARYDATA="}"#);
+        let res = serde_path_to_error::deserialize::<_, res::Get<32>>(d).unwrap();
         assert_eq!(res.payload, r#"THISISALOTOFBINARYDATA="#);
     }
 
@@ -281,7 +280,7 @@ mod tests {
 
     #[test]
     fn test_status() {
-        let (res, _) = serde_json_core::from_str::<res::Status>(
+        let d = &mut serde_json::Deserializer::from_str(
             r#"{
             "mode": "ready",
             "status": "successfully downloaded",
@@ -299,8 +298,8 @@ mod tests {
                 "type": "firmware"
             }
         }"#,
-        )
-        .unwrap();
+        );
+        let res = serde_path_to_error::deserialize::<_, res::Status>(d).unwrap();
 
         assert_eq!(res.mode, res::StatusMode::Ready);
         assert_eq!(res.status.unwrap(), "successfully downloaded");

--- a/src/hub.rs
+++ b/src/hub.rs
@@ -240,7 +240,8 @@ mod tests {
     "host": "a.notefile.net",
     "sn": "test-serial"
 }"##;
-        serde_json_core::from_slice::<res::Hub>(r).unwrap();
+        let d = &mut serde_json::Deserializer::from_slice(r);
+        serde_path_to_error::deserialize::<_, res::Hub>(d).unwrap();
     }
 
     #[test]

--- a/src/note.rs
+++ b/src/note.rs
@@ -303,7 +303,8 @@ mod tests {
     #[test]
     fn add_with_template() {
         let r = br##"{"template":true}"##;
-        serde_json_core::from_slice::<res::Add>(r).unwrap();
+        let d = &mut serde_json::Deserializer::from_slice(r);
+        serde_path_to_error::deserialize::<_, res::Add>(d).unwrap();
     }
 
     #[test]
@@ -321,7 +322,8 @@ mod tests {
         }
 
         let r = br##"{"note":"storage-info","body":{"last_id":19999}}"##;
-        let si = serde_json_core::from_slice::<res::Get<StorageIdInfo>>(r).unwrap();
+        let d = &mut serde_json::Deserializer::from_slice(r);
+        let si = serde_path_to_error::deserialize::<_, res::Get<StorageIdInfo>>(d).unwrap();
 
         println!("{:?}", si);
     }


### PR DESCRIPTION
This is the last relatively low hanging fruit patch that I have ready right now.

I would like your opinion on this before I merge it @gauteh.

This makes the test implementation little bit more noisy but it helps a lot when debugging issues with the json parsing as it ends up pointing to where the problem happened.

Not ported, only a few tests for now.