### PR TITLE
Add binary note transmission support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/gauteh/notecard-rs"
 defmt = { version = "1.0" }
 embedded-hal = "0.2.6"
 heapless = { version = "0.7", features = [ "serde", "ufmt-impl", "defmt-impl" ] }
+md-5 = { version = "0.10", default-features = false }
 serde = { version = "1", features = ["derive"], default-features = false }
 serde-json-core = "0.5.1"
 

--- a/src/card.rs
+++ b/src/card.rs
@@ -264,11 +264,85 @@ impl<'a, IOM: Write<SevenBitAddress> + Read<SevenBitAddress>, const BS: usize> C
         )?;
         Ok(FutureResponse::from(self.note))
     }
+
+    /// Checks the Notecard's binary store status.
+    ///
+    /// Pass `reset: true` to reset (clear) the binary store before use. Returns the current
+    /// decoded `length` and maximum `max` capacity in bytes.
+    ///
+    /// See <https://dev.blues.io/reference/notecard-api/card-requests/#card-binary>
+    pub fn binary(
+        self,
+        delay: &mut impl DelayMs<u16>,
+        reset: bool,
+    ) -> Result<FutureResponse<'a, res::Binary, IOM, BS>, NoteError> {
+        self.note.request(
+            delay,
+            req::Binary {
+                req: "card.binary",
+                reset: reset.then_some(true),
+            },
+        )?;
+        Ok(FutureResponse::from(self.note))
+    }
+
+    /// Prepares the Notecard to receive COBS-encoded binary data.
+    ///
+    /// After calling this and consuming the response with `.wait()`, immediately transmit the
+    /// COBS-encoded binary data (including the trailing `'\n'` EOP byte) using
+    /// [`Notecard::transmit_data`].
+    ///
+    /// - `cobs`: encoded data length, **not** including the EOP byte
+    /// - `offset`: byte offset into the Notecard binary store (for multi-chunk transfers)
+    /// - `status`: lowercase hex MD5 of the **unencoded** data
+    ///
+    /// See <https://dev.blues.io/reference/notecard-api/card-requests/#card-binary-put>
+    pub fn binary_put(
+        self,
+        delay: &mut impl DelayMs<u16>,
+        cobs: u32,
+        offset: Option<u32>,
+        status: &str,
+    ) -> Result<FutureResponse<'a, res::Empty, IOM, BS>, NoteError> {
+        self.note.request(
+            delay,
+            req::BinaryPut {
+                req: "card.binary.put",
+                cobs,
+                offset,
+                status,
+            },
+        )?;
+        Ok(FutureResponse::from(self.note))
+    }
 }
 
 pub mod req {
 
     use super::*;
+
+    #[derive(Serialize, Default)]
+    pub struct Binary {
+        pub req: &'static str,
+
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub reset: Option<bool>,
+    }
+
+    #[derive(Serialize)]
+    pub struct BinaryPut<'a> {
+        pub req: &'static str,
+
+        /// COBS-encoded data length (excluding the trailing EOP `'\n'`).
+        pub cobs: u32,
+
+        /// Byte offset into the Notecard binary store for multi-chunk transfers.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub offset: Option<u32>,
+
+        /// Lowercase hex MD5 of the **unencoded** binary data.
+        pub status: &'a str,
+    }
 
     #[derive(Deserialize, Serialize, Debug, defmt::Format, Default)]
     pub struct Aux {
@@ -419,6 +493,16 @@ pub mod res {
 
     #[derive(Deserialize, Debug, defmt::Format)]
     pub struct Empty {}
+
+    /// Response from `card.binary` — reports the binary store status.
+    #[derive(Deserialize, Debug, defmt::Format)]
+    pub struct Binary {
+        /// Current decoded data length in the binary store.
+        pub length: Option<u32>,
+
+        /// Maximum capacity of the binary store.
+        pub max: Option<u32>,
+    }
 
     #[derive(Deserialize, Debug, defmt::Format)]
     pub struct LocationTrack {

--- a/src/cobs.rs
+++ b/src/cobs.rs
@@ -1,0 +1,157 @@
+//! COBS encoding with EOP=`'\n'` (0x0A) as used by the Blues Notecard binary protocol.
+//!
+//! This is standard COBS encoding where all output bytes (code bytes and data bytes) are XOR'd
+//! with the EOP byte (0x0A). This eliminates all 0x0A bytes from the encoded output so that
+//! `'\n'` can unambiguously mark the end of a binary packet.
+//!
+//! See: <https://github.com/blues/note-c/blob/master/n_cobs.c>
+
+/// End-of-packet byte used by the Blues Notecard binary protocol.
+pub const EOP: u8 = b'\n';
+
+/// Minimum buffer size needed to COBS-encode `input_len` bytes, **including** the EOP byte.
+///
+/// Pass the result of this function as the minimum `enc_buf` length when calling
+/// [`crate::note::Note::add_binary`].
+pub fn max_encoded_len(input_len: usize) -> usize {
+    let code_bytes = input_len / 254 + 1;
+    input_len + code_bytes + 1 // +1 for EOP
+}
+
+/// COBS-encode `src` into `dst` using `EOP = '\n'`.
+///
+/// Returns the encoded length, **not** including the EOP byte. The caller must write `EOP`
+/// (`b'\n'`) at `dst[enc_len]` to terminate the packet.
+///
+/// `dst` must be at least `max_encoded_len(src.len()) - 1` bytes long.
+pub fn encode(src: &[u8], dst: &mut [u8]) -> usize {
+    let mut code: u8 = 1;
+    let mut code_pos = 0usize;
+    let mut dst_idx = 1usize;
+
+    for &byte in src {
+        if code == 0xFF {
+            dst[code_pos] = code ^ EOP;
+            code_pos = dst_idx;
+            dst_idx += 1;
+            code = 1;
+        }
+        if byte == 0x00 {
+            dst[code_pos] = code ^ EOP;
+            code_pos = dst_idx;
+            dst_idx += 1;
+            code = 1;
+        } else {
+            dst[dst_idx] = byte ^ EOP;
+            dst_idx += 1;
+            code += 1;
+        }
+    }
+
+    dst[code_pos] = code ^ EOP;
+    dst_idx
+}
+
+/// COBS-decode `src` (encoded with `EOP = '\n'`) into `dst`.
+///
+/// `src` must **not** include the trailing EOP byte.
+/// Returns the decoded length.
+pub fn decode(src: &[u8], dst: &mut [u8]) -> usize {
+    let mut dst_idx = 0usize;
+    let mut src_idx = 0usize;
+    let mut code: u8 = 0xFF; // sentinel: skip zero insertion on first iteration
+
+    while src_idx < src.len() {
+        if code != 0xFF {
+            dst[dst_idx] = 0;
+            dst_idx += 1;
+        }
+
+        code = src[src_idx] ^ EOP;
+        src_idx += 1;
+
+        if code == 0 {
+            break;
+        }
+
+        let n = (code - 1) as usize;
+        let available = src.len() - src_idx;
+        let n = n.min(available);
+
+        for i in 0..n {
+            dst[dst_idx + i] = src[src_idx + i] ^ EOP;
+        }
+        dst_idx += n;
+        src_idx += n;
+    }
+
+    dst_idx
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn roundtrip(data: &[u8]) {
+        let enc_max = max_encoded_len(data.len());
+        let mut enc_buf = vec![0u8; enc_max];
+        let enc_len = encode(data, &mut enc_buf);
+        enc_buf[enc_len] = EOP;
+        for &b in &enc_buf[..enc_len] {
+            assert_ne!(b, EOP, "encoded output contains EOP byte");
+        }
+        let mut dec_buf = vec![0u8; data.len() + 1];
+        let dec_len = decode(&enc_buf[..enc_len], &mut dec_buf);
+        assert_eq!(dec_len, data.len());
+        assert_eq!(&dec_buf[..dec_len], data);
+    }
+
+    #[test]
+    fn test_empty() {
+        roundtrip(&[]);
+    }
+
+    #[test]
+    fn test_single_zero() {
+        roundtrip(&[0x00]);
+    }
+
+    #[test]
+    fn test_single_eop() {
+        roundtrip(&[EOP]);
+    }
+
+    #[test]
+    fn test_zeros() {
+        roundtrip(&[0x00, 0x00, 0x00]);
+    }
+
+    #[test]
+    fn test_mixed() {
+        roundtrip(&[0x01, 0x00, 0x02, EOP, 0x03]);
+    }
+
+    #[test]
+    fn test_all_eop() {
+        roundtrip(&[EOP; 10]);
+    }
+
+    #[test]
+    fn test_long() {
+        let data: Vec<u8> = (0..512).map(|i| i as u8).collect();
+        roundtrip(&data);
+    }
+
+    #[test]
+    fn test_no_eop_in_encoded() {
+        // Any byte sequence should produce encoded output with no EOP bytes
+        for len in 0..=300usize {
+            let data: Vec<u8> = (0..len).map(|i| i as u8).collect();
+            let mut enc_buf = vec![0u8; max_encoded_len(len)];
+            let enc_len = encode(&data, &mut enc_buf);
+            for (pos, &b) in enc_buf[..enc_len].iter().enumerate() {
+                assert_ne!(b, EOP, "EOP found at position {pos} for len {len}");
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -461,17 +461,19 @@ impl<IOM: Write<SevenBitAddress> + Read<SevenBitAddress>, const BUF_SIZE: usize>
     fn send_request(&mut self, delay: &mut impl DelayMs<u16>) -> Result<(), NoteError> {
         // This is presumably limited by the notecard firmware.
         const CHUNK_LENGTH_MAX: usize = 127;
-        // 127 bytes is the I2C max supported by the Notecard firmware.
-        const CHUNK_LENGTH_I: usize = 127;
+        // This is a limit that was required on some Arduinos. Can probably be increased up to
+        // `CHUNK_LENGTH_MAX`. Should maybe be configurable.
+        const CHUNK_LENGTH_I: usize = 30;
         const CHUNK_LENGTH: usize = if CHUNK_LENGTH_I < CHUNK_LENGTH_MAX {
             CHUNK_LENGTH_I
         } else {
             CHUNK_LENGTH_MAX
         };
 
-        // Use 2×CHUNK_LENGTH (254 bytes) as segment boundary to get 2 chunks
-        // per segment rather than 1, reducing the relative cost of segment_delay.
-        const SEGMENT_LENGTH: usize = 2 * CHUNK_LENGTH;
+        // `note-c` uses `250` for `SEGMENT_LENGTH`. Round to closest divisible
+        // by CHUNK_LENGTH so that we don't end up with unnecessarily fragmented
+        // chunks. https://github.com/blues/note-c/blob/master/n_lib.h#L40 .
+        const SEGMENT_LENGTH: usize = (250 / CHUNK_LENGTH) * CHUNK_LENGTH;
 
         if !matches!(self.state, NoteState::Request) {
             warn!("note: request: wrong-state, resetting before new request.");
@@ -534,13 +536,13 @@ impl<IOM: Write<SevenBitAddress> + Read<SevenBitAddress>, const BUF_SIZE: usize>
         data: &[u8],
     ) -> Result<(), NoteError> {
         const CHUNK_LENGTH_MAX: usize = 127;
-        const CHUNK_LENGTH_I: usize = 127;
+        const CHUNK_LENGTH_I: usize = 30;
         const CHUNK_LENGTH: usize = if CHUNK_LENGTH_I < CHUNK_LENGTH_MAX {
             CHUNK_LENGTH_I
         } else {
             CHUNK_LENGTH_MAX
         };
-        const SEGMENT_LENGTH: usize = 2 * CHUNK_LENGTH;
+        const SEGMENT_LENGTH: usize = (250 / CHUNK_LENGTH) * CHUNK_LENGTH;
 
         if !matches!(self.state, NoteState::Request) {
             return Err(NoteError::WrongState);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 //! Protocol for transmitting: <https://dev.blues.io/notecard/notecard-guides/serial-over-i2c-protocol/>
 //! API: <https://dev.blues.io/reference/notecard-api/introduction/>
 //!
-#![feature(type_changing_struct_update)]
 #![cfg_attr(not(test), no_std)]
 
 use core::convert::Infallible;
@@ -16,6 +15,7 @@ use heapless::{String, Vec};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 pub mod card;
+pub mod cobs;
 pub mod dfu;
 pub mod hub;
 pub mod note;
@@ -217,7 +217,12 @@ impl<IOM: Write<SevenBitAddress> + Read<SevenBitAddress>, const BUF_SIZE: usize>
         } else {
             Ok(Notecard {
                 buf: Vec::<_, B>::from_slice(&self.buf).unwrap(),
-                ..self
+                i2c: self.i2c,
+                addr: self.addr,
+                state: self.state,
+                response_timeout: self.response_timeout,
+                chunk_delay: self.chunk_delay,
+                segment_delay: self.segment_delay,
             })
         }
     }
@@ -513,6 +518,55 @@ impl<IOM: Write<SevenBitAddress> + Read<SevenBitAddress>, const BUF_SIZE: usize>
 
         self.state = NoteState::Poll(0);
 
+        Ok(())
+    }
+
+    /// Transmit raw bytes to the Notecard without JSON framing and without waiting for a response.
+    ///
+    /// Used for binary data transmission: call this immediately after consuming the response from
+    /// a `card.binary.put` JSON request to deliver the COBS-encoded binary payload.
+    ///
+    /// The `data` slice should include the trailing `'\n'` EOP byte at the end.
+    ///
+    /// State must be [`NoteState::Request`]; state remains `Request` after this call since no
+    /// response is expected for raw binary data.
+    pub(crate) fn transmit_data(
+        &mut self,
+        delay: &mut impl DelayMs<u16>,
+        data: &[u8],
+    ) -> Result<(), NoteError> {
+        const CHUNK_LENGTH_MAX: usize = 127;
+        const CHUNK_LENGTH_I: usize = 30;
+        const CHUNK_LENGTH: usize = if CHUNK_LENGTH_I < CHUNK_LENGTH_MAX {
+            CHUNK_LENGTH_I
+        } else {
+            CHUNK_LENGTH_MAX
+        };
+        const SEGMENT_LENGTH: usize = (250 / CHUNK_LENGTH) * CHUNK_LENGTH;
+
+        if !matches!(self.state, NoteState::Request) {
+            return Err(NoteError::WrongState);
+        }
+
+        trace!("note: transmitting {} bytes of raw binary data", data.len());
+
+        let mut buf = Vec::<u8, { CHUNK_LENGTH + 1 }>::new();
+        for segment in data.chunks(SEGMENT_LENGTH) {
+            for c in segment.chunks(buf.capacity() - 1) {
+                buf.push(c.len() as u8).unwrap();
+                buf.extend_from_slice(c).unwrap();
+
+                self.i2c
+                    .write(self.addr, &buf)
+                    .map_err(|_| NoteError::I2cWriteError)?;
+
+                buf.clear();
+                delay.delay_ms(self.chunk_delay);
+            }
+            delay.delay_ms(self.segment_delay);
+        }
+
+        // State remains Request — no response is expected for raw binary data.
         Ok(())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -461,19 +461,17 @@ impl<IOM: Write<SevenBitAddress> + Read<SevenBitAddress>, const BUF_SIZE: usize>
     fn send_request(&mut self, delay: &mut impl DelayMs<u16>) -> Result<(), NoteError> {
         // This is presumably limited by the notecard firmware.
         const CHUNK_LENGTH_MAX: usize = 127;
-        // This is a limit that was required on some Arduinos. Can probably be increased up to
-        // `CHUNK_LENGTH_MAX`. Should maybe be configurable.
-        const CHUNK_LENGTH_I: usize = 30;
+        // 127 bytes is the I2C max supported by the Notecard firmware.
+        const CHUNK_LENGTH_I: usize = 127;
         const CHUNK_LENGTH: usize = if CHUNK_LENGTH_I < CHUNK_LENGTH_MAX {
             CHUNK_LENGTH_I
         } else {
             CHUNK_LENGTH_MAX
         };
 
-        // `note-c` uses `250` for `SEGMENT_LENGTH`. Round to closest divisible
-        // by CHUNK_LENGTH so that we don't end up with unnecessarily fragmented
-        // chunks. https://github.com/blues/note-c/blob/master/n_lib.h#L40 .
-        const SEGMENT_LENGTH: usize = (250 / CHUNK_LENGTH) * CHUNK_LENGTH;
+        // Use 2×CHUNK_LENGTH (254 bytes) as segment boundary to get 2 chunks
+        // per segment rather than 1, reducing the relative cost of segment_delay.
+        const SEGMENT_LENGTH: usize = 2 * CHUNK_LENGTH;
 
         if !matches!(self.state, NoteState::Request) {
             warn!("note: request: wrong-state, resetting before new request.");
@@ -536,13 +534,13 @@ impl<IOM: Write<SevenBitAddress> + Read<SevenBitAddress>, const BUF_SIZE: usize>
         data: &[u8],
     ) -> Result<(), NoteError> {
         const CHUNK_LENGTH_MAX: usize = 127;
-        const CHUNK_LENGTH_I: usize = 30;
+        const CHUNK_LENGTH_I: usize = 127;
         const CHUNK_LENGTH: usize = if CHUNK_LENGTH_I < CHUNK_LENGTH_MAX {
             CHUNK_LENGTH_I
         } else {
             CHUNK_LENGTH_MAX
         };
-        const SEGMENT_LENGTH: usize = (250 / CHUNK_LENGTH) * CHUNK_LENGTH;
+        const SEGMENT_LENGTH: usize = 2 * CHUNK_LENGTH;
 
         if !matches!(self.state, NoteState::Request) {
             return Err(NoteError::WrongState);

--- a/src/note.rs
+++ b/src/note.rs
@@ -55,6 +55,121 @@ impl<'a, IOM: Write<SevenBitAddress> + Read<SevenBitAddress>, const BS: usize> N
         Ok(FutureResponse::from(self.note))
     }
 
+    /// Adds a note with a raw binary payload to a notefile using the Notecard's binary store.
+    ///
+    /// This method implements the full `card.binary` → `card.binary.put` → raw I2C transmit →
+    /// verify → `note.add` protocol as documented in the Blues Notecard binary data guide.
+    ///
+    /// The `payload` bytes are COBS-encoded (with EOP = `'\n'`) and transmitted directly over
+    /// I2C, bypassing the normal JSON request path. The Notecard then commits the binary from its
+    /// internal buffer when the final `note.add` with `"binary": true` is sent.
+    ///
+    /// # Parameters
+    ///
+    /// - `payload`: raw binary data to transmit
+    /// - `enc_buf`: caller-supplied working buffer for COBS encoding; must be at least
+    ///   [`crate::cobs::max_encoded_len`]`(payload.len())` bytes
+    ///
+    /// # Errors
+    ///
+    /// Returns [`NoteError::BufOverflow`] if `enc_buf` is too small or if `payload` exceeds
+    /// the Notecard's binary store capacity.
+    /// Returns [`NoteError::NotecardErr`] (containing `{bad-bin}`) if the Notecard reports a
+    /// checksum mismatch after transmission — the caller should retry.
+    ///
+    /// # References
+    ///
+    /// - <https://dev.blues.io/reference/notecard-api/card-requests/#card-binary>
+    /// - <https://dev.blues.io/reference/notecard-api/card-requests/#card-binary-put>
+    /// - <https://github.com/blues/note-c/blob/master/n_helpers.c> (`NoteBinaryStoreTransmit`)
+    pub fn add_binary<T: Serialize + Default>(
+        self,
+        delay: &mut impl DelayMs<u16>,
+        file: Option<&str>,
+        note_id: Option<&str>,
+        body: Option<T>,
+        payload: &[u8],
+        enc_buf: &mut [u8],
+        sync: bool,
+    ) -> Result<FutureResponse<'a, res::Add, IOM, BS>, NoteError> {
+        use crate::cobs;
+        use md5::{Digest, Md5};
+
+        let nc = self.note;
+
+        // Step 1: Initialize the binary store and check capacity.
+        nc.request(
+            delay,
+            inner::CardBinary {
+                req: "card.binary",
+                reset: Some(true),
+            },
+        )?;
+        let bin_info =
+            FutureResponse::<inner::CardBinaryInfo, IOM, BS>::from(nc).wait(delay)?;
+
+        if let Some(max) = bin_info.max {
+            if payload.len() > max as usize {
+                return Err(NoteError::BufOverflow);
+            }
+        }
+
+        // Step 2: COBS-encode the payload into enc_buf.
+        let enc_min = cobs::max_encoded_len(payload.len());
+        if enc_buf.len() < enc_min {
+            return Err(NoteError::BufOverflow);
+        }
+        let enc_len = cobs::encode(payload, enc_buf);
+        enc_buf[enc_len] = cobs::EOP;
+
+        // Step 3: Compute the MD5 hash of the unencoded payload as a lowercase hex string.
+        let hash = Md5::digest(payload);
+        let mut md5_str = heapless::String::<32>::new();
+        core::fmt::write(&mut md5_str, format_args!("{:x}", hash)).unwrap();
+
+        // Step 4: Issue card.binary.put — prepare the Notecard to receive binary data.
+        nc.request(
+            delay,
+            inner::CardBinaryPut {
+                req: "card.binary.put",
+                cobs: enc_len as u32,
+                offset: None,
+                status: &md5_str,
+            },
+        )?;
+        FutureResponse::<res::Empty, IOM, BS>::from(nc).wait(delay)?;
+
+        // Step 5: Transmit the COBS-encoded binary data (including the EOP `'\n'`) over I2C.
+        nc.transmit_data(delay, &enc_buf[..enc_len + 1])?;
+
+        // Step 6: Verify the binary was received and checksum is valid.
+        // The Notecard returns {"err":"...{bad-bin}..."} on checksum mismatch, which
+        // FutureResponse::wait() propagates as NoteError::NotecardErr.
+        nc.request(
+            delay,
+            inner::CardBinary {
+                req: "card.binary",
+                reset: None,
+            },
+        )?;
+        FutureResponse::<inner::CardBinaryInfo, IOM, BS>::from(nc).wait(delay)?;
+
+        // Step 7: Commit the binary data to the notefile with note.add { "binary": true }.
+        nc.request(
+            delay,
+            req::Add::<T> {
+                req: "note.add",
+                file: str_string(file)?,
+                note: str_string(note_id)?,
+                body,
+                binary: Some(true),
+                sync: Some(sync),
+                ..<req::Add<T> as Default>::default()
+            },
+        )?;
+        Ok(FutureResponse::from(nc))
+    }
+
     /// Updates a Note in a DB Notefile by its ID, replacing the existing body and/or payload.
     pub fn update<T: Serialize + Default>(
         self,
@@ -194,6 +309,9 @@ mod req {
         pub sync: Option<bool>,
 
         #[serde(skip_serializing_if = "Option::is_none")]
+        pub binary: Option<bool>,
+
+        #[serde(skip_serializing_if = "Option::is_none")]
         pub key: Option<heapless::String<20>>,
 
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -295,6 +413,39 @@ pub mod res {
     }
 }
 
+/// Private request/response types used by [`Note::add_binary`].
+mod inner {
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Serialize, Default)]
+    pub struct CardBinary {
+        pub req: &'static str,
+
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub reset: Option<bool>,
+    }
+
+    #[derive(Deserialize, Debug, defmt::Format, Default)]
+    pub struct CardBinaryInfo {
+        pub length: Option<u32>,
+        pub max: Option<u32>,
+    }
+
+    #[derive(Serialize)]
+    pub struct CardBinaryPut<'a> {
+        pub req: &'static str,
+
+        /// COBS-encoded data length (excluding the trailing EOP `'\n'`).
+        pub cobs: u32,
+
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub offset: Option<u32>,
+
+        /// Lowercase hex MD5 of the **unencoded** binary data.
+        pub status: &'a str,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -369,5 +520,18 @@ mod tests {
         let cmd = serde_json_core::to_vec::<_, { BUF_SIZE }>(&add).unwrap();
 
         println!("cmd size: {}", cmd.len());
+    }
+
+    #[test]
+    fn md5_hex_string() {
+        use core::fmt::Write;
+        use md5::{Digest, Md5};
+
+        // Known MD5: "hello world" → 5eb63bbbe01eeed093cb22bb8f5acdc3
+        let hash = Md5::digest(b"hello world");
+        let mut s = heapless::String::<32>::new();
+        write!(s, "{:x}", hash).unwrap();
+        assert_eq!(s.as_str(), "5eb63bbbe01eeed093cb22bb8f5acdc3");
+        assert_eq!(s.len(), 32);
     }
 }

--- a/src/note.rs
+++ b/src/note.rs
@@ -261,8 +261,10 @@ impl<'a, IOM: Write<SevenBitAddress> + Read<SevenBitAddress>, const BS: usize> N
         port: Option<u32>,
         delete: Option<bool>,
     ) -> Result<FutureResponse<'a, res::Template, IOM, BS>, NoteError> {
-        if let Some(port) = port && !(1..=100).contains(&port) {
+        if let Some(port) = port {
+            if !(1..=100).contains(&port) {
                 return Err(NoteError::InvalidRequest);
+            }
         }
 
         let format = match format {


### PR DESCRIPTION
Implement the Notecard binary protocol for sending notes without base64 overhead, following the blues/note-c reference implementation.

- src/cobs.rs: New COBS codec (XOR variant, EOP='\n') with encode, decode, max_encoded_len, and tests
- src/lib.rs: Add transmit_data() for raw I2C binary transmission; struct fields explicitly in resize_buf()
- src/card.rs: Add card.binary and card.binary.put request methods and supporting request/response structs
- src/note.rs: Add note.add_binary() implementing the full protocol (reset → COBS-encode → MD5 → card.binary.put → transmit → verify → note.add); add binary field to req::Add; add inner module for private request/response types; use LowerHex via generic-array for MD5 hex formatting; add md5_hex_string test
- Cargo.toml: Add md-5 = { version = "0.10", default-features = false }

Still geared towards eh-0, can't upgrade yet.